### PR TITLE
UAEPass authenticator - groupId removed from the child pom

### DIFF
--- a/components/uaepass-authenticator/pom.xml
+++ b/components/uaepass-authenticator/pom.xml
@@ -28,7 +28,6 @@
     </parent>
 
     <modelVersion>4.0.0</modelVersion>
-    <groupId>uae-pass-federated-authenticator</groupId>
     <artifactId>org.wso2.carbon.identity.authenticator.uaepass</artifactId>
     <packaging>bundle</packaging>
 


### PR DESCRIPTION
## Purpose
> Remove the group id from the child pom.
The additional details available in the previous [PR](https://github.com/wso2-extensions/identity-outbound-auth-uaepass/pull/1)
