### PR TITLE
Redirect to error page UAEPass Authentication Errors

### DIFF
--- a/.connector-store/meta.json
+++ b/.connector-store/meta.json
@@ -33,6 +33,12 @@
             "products": [
                 "IS 7.0.0"
             ]
+        },
+        {
+            "tagName": "v1.1.2",
+            "products": [
+                "IS 7.0.0"
+            ]
         }
     ]
 }

--- a/components/uaepass-authenticator/src/main/java/org/wso2/carbon/identity/authenticator/uaepass/UAEPassAuthenticator.java
+++ b/components/uaepass-authenticator/src/main/java/org/wso2/carbon/identity/authenticator/uaepass/UAEPassAuthenticator.java
@@ -38,7 +38,6 @@ import org.apache.oltu.oauth2.common.exception.OAuthProblemException;
 import org.apache.oltu.oauth2.common.exception.OAuthSystemException;
 import org.apache.oltu.oauth2.common.message.types.GrantType;
 import org.wso2.carbon.base.MultitenantConstants;
-import org.wso2.carbon.identity.application.authentication.framework.AbstractApplicationAuthenticator;
 import org.wso2.carbon.identity.application.authentication.framework.FederatedApplicationAuthenticator;
 import org.wso2.carbon.identity.application.authentication.framework.config.model.ExternalIdPConfig;
 import org.wso2.carbon.identity.application.authentication.framework.context.AuthenticationContext;
@@ -52,6 +51,7 @@ import org.wso2.carbon.identity.application.authentication.framework.util.Framew
 import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkUtils;
 import org.wso2.carbon.identity.application.authenticator.oidc.NativeSDKBasedFederatedOAuthClientResponse;
 import org.wso2.carbon.identity.application.authenticator.oidc.OIDCAuthenticatorConstants;
+import org.wso2.carbon.identity.application.authenticator.oidc.OpenIDConnectAuthenticator;
 import org.wso2.carbon.identity.application.authenticator.oidc.util.OIDCTokenValidationUtil;
 import org.wso2.carbon.identity.application.common.model.ClaimMapping;
 import org.wso2.carbon.identity.application.common.model.IdentityProvider;
@@ -73,6 +73,7 @@ import org.wso2.carbon.idp.mgt.util.IdPManagementConstants;
 import org.wso2.carbon.user.api.UserRealm;
 import org.wso2.carbon.user.api.UserStoreException;
 import org.wso2.carbon.user.core.UserStoreManager;
+
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
@@ -108,7 +109,7 @@ import static org.wso2.carbon.identity.authenticator.uaepass.UAEPassAuthenticato
  * commonauthLogout of the UAEPAss, claim mapping via both id token and user info, UAEPAss Environment
  * selection (Staging / Production), and obtaining user input data.
  */
-public class UAEPassAuthenticator extends AbstractApplicationAuthenticator
+public class UAEPassAuthenticator extends OpenIDConnectAuthenticator
         implements FederatedApplicationAuthenticator {
 
     private static final Log LOG = LogFactory.getLog(UAEPassAuthenticator.class);
@@ -150,45 +151,6 @@ public class UAEPassAuthenticator extends AbstractApplicationAuthenticator
     public String getName() {
 
         return UAEPassAuthenticatorConstants.UAE.FEDERATED_IDP_COMPONENT_NAME;
-    }
-
-    /**
-     * Returns the claim dialect URL.
-     * Since authenticator supports OIDC, the dialect URL is OIDC dialect.
-     *
-     * @return String  The dialect which is supposed to map UAEPass claims.
-     */
-    @Override
-    public String getClaimDialectURI() {
-
-        return UAEPassAuthenticatorConstants.UAEPassRuntimeConstants.OIDC_DIALECT;
-    }
-
-    /**
-     * Returns a unique string to identify each request and response separately.
-     * This contains the session id, processed by the WSO2 IS.
-     *
-     * @param request  The request that is received by the authenticator.
-     * @return String  Returns the state parameter value that is carried by the request.
-     */
-    @Override
-    public String getContextIdentifier(HttpServletRequest request) {
-
-        if (isAPIBasedAuthenticationFlow(request, null)) {
-            return request.getParameter(UAEPassAuthenticatorConstants.SESSION_DATA_KEY_PARAM);
-        }
-
-        String state = request.getParameter(OAUTH2_PARAM_STATE);
-        if (StringUtils.isNotBlank(state)) {
-            return state.split(",")[0];
-        } else {
-            if (LOG.isDebugEnabled()) {
-                LOG.debug("A unique identifier cannot be issued for both Request and Response. " +
-                        "ContextIdentifier is NULL.");
-            }
-
-            return null;
-        }
     }
 
     /**
@@ -477,24 +439,6 @@ public class UAEPassAuthenticator extends AbstractApplicationAuthenticator
             }
         } else {
             super.initiateLogoutRequest(request, response, context);
-        }
-    }
-
-    /**
-     * After a successful logout, WSO2 IS returns this response.
-     * Contains the details about the SP.
-     *
-     * @param request   The request that is received by the authenticator.
-     * @param response  The response that is received to the authenticator.
-     * @param context   The Authentication context received by authenticator.
-     */
-    @Override
-    protected void processLogoutResponse(HttpServletRequest request, HttpServletResponse response,
-                                         AuthenticationContext context) {
-
-        if (LOG.isDebugEnabled()) {
-                LOG.debug("Handled logout response from service provider " + context.getServiceProviderName() +
-                        " in tenant domain " + context.getTenantDomain());
         }
     }
 
@@ -1103,12 +1047,6 @@ public class UAEPassAuthenticator extends AbstractApplicationAuthenticator
     private String getFileConfigValue(String fileConfigKey) {
 
         return getAuthenticatorConfig().getParameterMap().get(fileConfigKey);
-    }
-
-    @Override
-    public boolean isAPIBasedAuthenticationSupported() {
-
-        return true;
     }
 
     /**

--- a/components/uaepass-authenticator/src/main/java/org/wso2/carbon/identity/authenticator/uaepass/UAEPassAuthenticator.java
+++ b/components/uaepass-authenticator/src/main/java/org/wso2/carbon/identity/authenticator/uaepass/UAEPassAuthenticator.java
@@ -530,7 +530,6 @@ public class UAEPassAuthenticator extends AbstractApplicationAuthenticator
         }
     }
 
-
     private String getErrorPageURL() throws AuthenticationFailedException {
 
         try {

--- a/components/uaepass-authenticator/src/main/java/org/wso2/carbon/identity/authenticator/uaepass/UAEPassAuthenticatorConstants.java
+++ b/components/uaepass-authenticator/src/main/java/org/wso2/carbon/identity/authenticator/uaepass/UAEPassAuthenticatorConstants.java
@@ -35,6 +35,13 @@ public class UAEPassAuthenticatorConstants {
     public static final String SCOPE_PARAM_SUFFIX = "_scope_param";
     public static final String SCOPE = "scope";
     public static final String REDIRECT_URL = "REDIRECT_URL";
+    public static final String AUTHENTICATION_ERROR_PAGE_URL = "authenticationendpoint/uaePassError.jsp";
+    public static final String AUTHENTICATORS_QUERY_PARAM = "&authenticators=";
+    public static final String ERROR_USER_CANCELLED_QUERY_PARAMS =
+            "&authFailure=true&authFailureMsg=cancelled.on.app";
+    public static final String ERROR_INVALID_REQUEST_QUERY_PARAMS =
+            "&authFailure=true&authFailureMsg=invalid.request";
+    public static final String CANCELLED_ON_APP_ERROR = "cancelledOnApp";
 
     private UAEPassAuthenticatorConstants() {
 

--- a/components/uaepass-authenticator/src/main/java/org/wso2/carbon/identity/authenticator/uaepass/UAEPassAuthenticatorConstants.java
+++ b/components/uaepass-authenticator/src/main/java/org/wso2/carbon/identity/authenticator/uaepass/UAEPassAuthenticatorConstants.java
@@ -42,6 +42,7 @@ public class UAEPassAuthenticatorConstants {
     public static final String ERROR_INVALID_REQUEST_QUERY_PARAMS =
             "&authFailure=true&authFailureMsg=invalid.request";
     public static final String CANCELLED_ON_APP_ERROR = "cancelledOnApp";
+    public static final String INVALID_REQUEST_ERROR = "invalid_request";
 
     private UAEPassAuthenticatorConstants() {
 


### PR DESCRIPTION
### Related Issue
- https://github.com/wso2/product-is/issues/22168

### Purpose
This pull request includes significant updates to the `UAEPassAuthenticator` class, enhancing its functionality and error handling capabilities. The most important changes include the addition of new imports and constants, the implementation of a new `process` method to handle authentication and logout flows, and improved error handling with redirection to error pages.

Enhancements to `UAEPassAuthenticator`:

* Added new imports for `AuthenticatorFlowStatus` and `User` to support the new `process` method. [[1]](diffhunk://#diff-b11863916813901d5a40fdbf37abae47ad3bcaf850cc4d355f56aa8dcf130915R42) [[2]](diffhunk://#diff-b11863916813901d5a40fdbf37abae47ad3bcaf850cc4d355f56aa8dcf130915R61)
* Introduced new constants in `UAEPassAuthenticatorConstants` for error handling and redirection purposes.

Implementation of new `process` method:

* Implemented `process` method to handle both authentication and logout flows, including the `processLogout` and `publishAuthenticationStepAttemptFailure` helper methods.

Improved error handling:

* Enhanced `processAuthenticationResponse` method to handle specific error cases and redirect to appropriate error pages using the new `redirectToErrorPage` and `getErrorPageURL` methods.